### PR TITLE
Only print the flexagon

### DIFF
--- a/css/worksheet.css
+++ b/css/worksheet.css
@@ -77,7 +77,7 @@ body {
 }
 
 @media print {
-    body{
+.pageTitle, .goggles-listing, .imageBox, ul, .foldingInstruction{
 	display:none;
     }
     

--- a/css/worksheet.css
+++ b/css/worksheet.css
@@ -75,3 +75,13 @@ body {
 	max-height: 400px;
 	overflow: hidden;
 }
+
+@media print {
+    body{
+	display:none;
+    }
+    
+    #template1{
+	display:block;
+    }
+}

--- a/css/worksheet.css
+++ b/css/worksheet.css
@@ -81,7 +81,7 @@ body {
 	display:none;
     }
     
-    #template1{
-	display:block;
+    .photo.template2{
+	display:block !important;
     }
 }

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
         </li>
         
         <li>
-        <p>Congratulations! You've just made a trihexaflexagon.</p>
+        <p>Congratulations! You just made a trihexaflexagon.</p>
         <img alt="Flexigon Folding" src="http://britton.disted.camosun.bc.ca/trihexaflexagon/flex8.jpg" height=249 width=262> 
         </li>
   


### PR DESCRIPTION
Just hides the other content (really quick and dirty)
Would like to make the image resizeable and rotate-able so it fits paper better (maybe a drop down list in the html with js to add the css)
